### PR TITLE
Don't exit if environment variables are not set

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -4,14 +4,14 @@ if [[ $DATADOG_API_KEY ]]; then
   sed -i -e "s/^.*api_key:.*$/api_key: ${DATADOG_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "DATADOG_API_KEY environment variable not set. Run: heroku config:add DATADOG_API_KEY=<your API key>"
-  exit 1
+  exit 0
 fi
 
 if [[ $HEROKU_APP_NAME ]]; then
   sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "HEROKU_APP_NAME environment variable not set. Run: heroku apps:info|grep ===|cut -d' ' -f2"
-  exit 1
+  exit 0
 fi
 
 if [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then

--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -4,14 +4,14 @@ if [[ $DATADOG_API_KEY ]]; then
   sed -i -e "s/^.*api_key:.*$/api_key: ${DATADOG_API_KEY}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "DATADOG_API_KEY environment variable not set. Run: heroku config:add DATADOG_API_KEY=<your API key>"
-  exit 0
+  ENV_MISSING=1
 fi
 
 if [[ $HEROKU_APP_NAME ]]; then
   sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else
   echo "HEROKU_APP_NAME environment variable not set. Run: heroku apps:info|grep ===|cut -d' ' -f2"
-  exit 0
+  ENV_MISSING=1
 fi
 
 if [[ $DATADOG_HISTOGRAM_PERCENTILES ]]; then
@@ -21,6 +21,8 @@ fi
 (
   if [[ $DISABLE_DATADOG_AGENT ]]; then
     echo "DISABLE_DATADOG_AGENT environment variable is set, not starting the agent."
+  elif [[ $ENV_MISSING ]]; then
+    echo "Missing required environment variables, not starting the agent."
   else
     # Unset other PYTHONPATH/PYTHONHOME variables before we start
     unset PYTHONHOME PYTHONPATH


### PR DESCRIPTION
Failing with `exit 1` prevents usage of [Heroku exec](https://devcenter.heroku.com/changelog-items/1112). 